### PR TITLE
#31: close the test anyway after 50 connections or after 5 seconds.

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -37,8 +37,8 @@ jobs:
         while IFS= read -r file
         do
           echo $file
-          if [[ $file == ".github/workflows/linux.yml"* ]]; then
-            echo "This file is under the directory '.github/workflows/linux.yml'."
+          if [[ $file == ".github/workflows/linux.yaml"* ]]; then
+            echo "This file is under the directory '.github/workflows/linux.yaml'."
             echo "::set-output name=run_job::true"
             break
           fi

--- a/netreflected-tests/java/src/nettest/HelloNETSocket.java
+++ b/netreflected-tests/java/src/nettest/HelloNETSocket.java
@@ -72,9 +72,9 @@ public class HelloNETSocket {
         // trigger the thread closing procedure
         HelloNETSocketClient.run = false;
         Thread.Sleep(1000);
-        // wait for thread join
-        threadServer.Join();
-        threadClient.Join();
+        // wait for thread join, if not, close the test
+        threadServer.Join(5000);
+        threadClient.Join(5000);
         // close the application
         Environment.Exit(0);
         return;

--- a/netreflected-tests/java/src/nettest/HelloNETSocketClient.java
+++ b/netreflected-tests/java/src/nettest/HelloNETSocketClient.java
@@ -110,6 +110,8 @@ public class HelloNETSocketClient {
                         if (message != null) Console.WriteLine("Client data received {0}", new NetObject(message));
                     }
                     x++;
+                    //force a closure after 50 connections if no external closure happened before 
+                    if((x % 50) == 0) run = false;
                 } catch (ArgumentNullException | SocketException e) {
                     Console.WriteLine(e.getMessage());
                 }

--- a/netreflected-tests/kotlin/src/main/kotlin/nettest/HelloNETSocket.kt
+++ b/netreflected-tests/kotlin/src/main/kotlin/nettest/HelloNETSocket.kt
@@ -75,9 +75,9 @@ object HelloNETSocket {
         // trigger the thread closing procedure
         HelloNETSocketClient.run = false
         Thread.Sleep(1000)
-        // wait for thread join
-        threadServer.Join()
-        threadClient.Join()
+        // wait for thread join, if not, close the test
+        threadServer.Join(5000)
+        threadClient.Join(5000)
         // close the application
         Environment.Exit(0)
         return

--- a/netreflected-tests/kotlin/src/main/kotlin/nettest/HelloNETSocketClient.kt
+++ b/netreflected-tests/kotlin/src/main/kotlin/nettest/HelloNETSocketClient.kt
@@ -110,6 +110,8 @@ object HelloNETSocketClient {
                         if (message != null) Console.WriteLine("Client data received {0}", NetObject(message))
                     }
                     x++
+                    //force a closure after 50 connections if no external closure happened before 
+                    if((x % 50) == 0) run = false;
                 } catch (e: ArgumentNullException) {
                     Console.WriteLine(e.message)
                 } catch (e: SocketException) {

--- a/netreflected-tests/scala/src/main/scala/nettest/HelloNETSocket.scala
+++ b/netreflected-tests/scala/src/main/scala/nettest/HelloNETSocket.scala
@@ -76,9 +76,9 @@ object HelloNETSocket {
     // trigger the thread closing procedure
     HelloNETSocketClient.run = false
     Thread.Sleep(1000)
-    // wait for thread join
-    threadServer.Join()
-    threadClient.Join()
+    // wait for thread join, if not, close the test
+    threadServer.Join(5000)
+    threadClient.Join(5000)
     // close the application
     Environment.Exit(0)
   }

--- a/netreflected-tests/scala/src/main/scala/nettest/HelloNETSocketClient.scala
+++ b/netreflected-tests/scala/src/main/scala/nettest/HelloNETSocketClient.scala
@@ -112,6 +112,8 @@ object HelloNETSocketClient {
           if (message != null) Console.WriteLine("Client data received {0}", new NetObject(message))
         }
         x += 1
+        //force a closure after 50 connections if no external closure happened before 
+        if((x % 50) == 0) run = false
       } catch {
         case e@(_: ArgumentNullException | _: SocketException) =>
           Console.WriteLine(e.getMessage)


### PR DESCRIPTION
Close the test anyway after 50 connections or after 5 seconds, even if the thread not join.

## Description
The modification has two parts:
1. The client now ask for a server close after 50 connections
2. A timeout was added in the Join instruction to allow the close of the test even if the thread not join.
**NOTE**: A typo was fixed in _linux.yaml_ that avoided the triggering of the test.

## Related Issue
#31, Sometimes the .NET Framework tests still alive after long running, leading workflows to fail


## Motivation and Context
This resolve #31, Sometimes the .NET Framework tests still alive after long running, leading workflows to fail.


## How Has This Been Tested?
The wrong behavior is not systematic, so was resolved after a code review and an output analysis.
After the modification commit, actions was triggered to test if the issue still present: no issues were found in this phase.


## Screenshots (if appropriate):

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
