### PR TITLE
#61 (https://github.com/masesgroup/JCOReflector/issues/61#issuecomment-969069228): add compilation for .NET 6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,8 @@ jobs:
       - name: Build JCOReflectorCLI
         run: |
           dotnet build --no-incremental --framework netcoreapp3.1 --configuration Release src\JCOReflectorCLI.sln
-          dotnet build --no-incremental --framework net5.0 --configuration Release src\JCOReflectorCLI.sln  
+          dotnet build --no-incremental --framework net5.0 --configuration Release src\JCOReflectorCLI.sln
+          dotnet build --no-incremental --framework net6.0 --configuration Release src\JCOReflectorCLI.sln
           dotnet build --no-incremental --framework net461 --configuration Release src\JCOReflectorCLI.sln  
 
       # Runs a set of commands using the runners shell


### PR DESCRIPTION
## Description
Missing compilation for .NET 6

## Related Issue
#61 

## Motivation and Context
.NET 6 was not compiled

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
