### PR TITLE
#61 (https://github.com/masesgroup/JCOReflector/issues/61#issuecomment-969138035): added command-line parameter to set JDK to be used

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,7 @@ jobs:
       - name: Build JCOReflectorCLI
         run: |
           dotnet build --no-incremental --framework netcoreapp3.1 --configuration Release src\JCOReflectorCLI.sln
-          dotnet build --no-incremental --framework net5.0 --configuration Release src\JCOReflectorCLI.sln
-          dotnet build --no-incremental --framework net6.0 --configuration Release src\JCOReflectorCLI.sln
+          dotnet build --no-incremental --framework net5.0 --configuration Release src\JCOReflectorCLI.sln  
           dotnet build --no-incremental --framework net461 --configuration Release src\JCOReflectorCLI.sln  
 
       # Runs a set of commands using the runners shell
@@ -91,18 +90,21 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Build Java files
+      
         run: |
-          dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job
-          dotnet bin\net5.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job
-          dotnet bin\net6.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job
-          .\bin\net461\JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job
+          dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet bin\net5.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet bin\net6.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          .\bin\net461\JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        shell: cmd
           
       - name: Build JAR files
         run: |
-          dotnet .\bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job
-          dotnet .\bin\net5.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job
-          dotnet .\bin\net6.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job
-          .\bin\net461\JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job
+          dotnet .\bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet .\bin\net5.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet .\bin\net6.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          .\bin\net461\JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        shell: cmd
 
       - name: Compress release files
         run: | 


### PR DESCRIPTION
## Description
Fixed JDK in use

## Related Issue
#61 

## Motivation and Context
Default JDK was not available in Win22

## How Has This Been Tested?
N(A

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
