### PR TITLE
JCOReflectorCLI is now a right dotnet tool

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -77,11 +77,7 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: |
-          dotnet build --no-incremental --framework netcoreapp3.1 src\JCOReflectorCLI.sln
-          dotnet build --no-incremental --framework net5.0 src\JCOReflectorCLI.sln  
-          dotnet build --no-incremental --framework net6.0 src\JCOReflectorCLI.sln  
-          dotnet build --no-incremental --framework net461 src\JCOReflectorCLI.sln  
+        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -77,14 +77,14 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
+        run: dotnet build --no-incremental --configuration Release /p:Platform="Any CPU" src\JCOReflectorCLI.sln
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file
         run: |
-          Copy-Item .github\workflows\JCOReflectorCLI.runtimeconfig.json -Destination bin\netcoreapp3.1\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI.runtimeconfig.json -Destination bin\netcoreapp3.1\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
 
       - name: Switch to master netcoreapp3.1 help file
         run: |
@@ -157,19 +157,19 @@ jobs:
         shell: bash
 
       - name: Build netcoreapp3.1 Java Help files
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType BuildDocs -JobFile .github\workflows\builddocs_win19.job -CommitVersion ${{ env.GITHUB_COMMIT_MESSAGE }} -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType BuildDocs -JobFile .github\workflows\builddocs_win19.job -CommitVersion ${{ env.GITHUB_COMMIT_MESSAGE }} -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build net5.0 Java Help files
-        run: dotnet bin\net5.0\JCOReflectorCLI.dll -JobType BuildDocs -JobFile .github\workflows\builddocs_win19.job -CommitVersion ${{ env.GITHUB_COMMIT_MESSAGE }} -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType BuildDocs -JobFile .github\workflows\builddocs_win19.job -CommitVersion ${{ env.GITHUB_COMMIT_MESSAGE }} -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build net6.0 Java Help files
-        run: dotnet bin\net6.0\JCOReflectorCLI.dll -JobType BuildDocs -JobFile .github\workflows\builddocs_win19.job -CommitVersion ${{ env.GITHUB_COMMIT_MESSAGE }} -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType BuildDocs -JobFile .github\workflows\builddocs_win19.job -CommitVersion ${{ env.GITHUB_COMMIT_MESSAGE }} -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build net461 Java Help files
-        run: .\bin\net461\JCOReflectorCLI -JobType BuildDocs -JobFile .github\workflows\builddocs_win19.job -CommitVersion ${{ env.GITHUB_COMMIT_MESSAGE }} -JDKFolder %JAVA_HOME_11_X64%
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType BuildDocs -JobFile .github\workflows\builddocs_win19.job -CommitVersion ${{ env.GITHUB_COMMIT_MESSAGE }} -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Clean temporary files

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -92,15 +92,15 @@ jobs:
 
         - name: Build Java files
           run: |
-            dotnet bin/netcoreapp3.1/JCOReflectorCLI.dll -JobType Build -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/build_linux.job
-            dotnet bin/net5.0/JCOReflectorCLI.dll -JobType Build -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/build_linux.job
-            dotnet bin/net6.0/JCOReflectorCLI.dll -JobType Build -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/build_linux.job
+            dotnet bin/netcoreapp3.1/MASES.JCOReflectorCLI.dll -JobType Build -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/build_linux.job
+            dotnet bin/net5.0/MASES.JCOReflectorCLI.dll -JobType Build -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/build_linux.job
+            dotnet bin/net6.0/MASES.JCOReflectorCLI.dll -JobType Build -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/build_linux.job
 
         - name: Build JAR files
           run: |
-            dotnet bin/netcoreapp3.1/JCOReflectorCLI.dll -JobType CreateJars -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/createjars_core3.1_linux.job
-            dotnet bin/net5.0/JCOReflectorCLI.dll -JobType CreateJars -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/createjars_core5.0_linux.job
-            dotnet bin/net6.0/JCOReflectorCLI.dll -JobType CreateJars -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/createjars_core6.0_linux.job
+            dotnet bin/netcoreapp3.1/MASES.JCOReflectorCLI.dll -JobType CreateJars -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/createjars_core3.1_linux.job
+            dotnet bin/net5.0/MASES.JCOReflectorCLI.dll -JobType CreateJars -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/createjars_core5.0_linux.job
+            dotnet bin/net6.0/MASES.JCOReflectorCLI.dll -JobType CreateJars -JDKFolder /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/ -JobFile .github/workflows/createjars_core6.0_linux.job
 
         - name: Build Java test source file .NET Core 3.1
           run: javac -cp ./bin/netcoreapp3.1/JCOReflector.jar ./netreflected-tests/java/src/hierarchy/*.java ./netreflected-tests/java/src/mscorlib/*.java ./netreflected-tests/java/src/nettest/*.java ./netreflected-tests/java/src/refout/*.java

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -96,17 +96,17 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Copy configuration file
         run: |
-          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
 
       - name: Build net5.0 Maven POM files
-        run: dotnet bin\net5.0\JCOReflectorCLI.dll -JobType CreatePOM -JobFile .github\workflows\createpom_win19.job
+        run: dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType CreatePOM -JobFile .github\workflows\createpom_win19.job
         
       - name: Build net6.0 Maven POM files
-        run: dotnet bin\net6.0\JCOReflectorCLI.dll -JobType CreatePOM -JobFile .github\workflows\createpom_win19.job
+        run: dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType CreatePOM -JobFile .github\workflows\createpom_win19.job
          
       - name: Build net461 Maven POM files
-        run: .\bin\net461\JCOReflectorCLI -JobType CreatePOM -JobFile .github\workflows\createpom_win19.job
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType CreatePOM -JobFile .github\workflows\createpom_win19.job
 
       - name: Set up Apache Maven Central
         uses: actions/setup-java@v1

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           nuget-version: '5.x'
           
-      - run: nuget pack src\JCOReflectorCLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
+      - run: nuget pack src\CLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -73,11 +73,13 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: |
-          dotnet build --no-incremental --framework netcoreapp3.1 --configuration Release src\JCOReflectorCLI.sln
-          dotnet build --no-incremental --framework net5.0 --configuration Release src\JCOReflectorCLI.sln  
-          dotnet build --no-incremental --framework net6.0 --configuration Release src\JCOReflectorCLI.sln  
-          dotnet build --no-incremental --framework net461 --configuration Release src\JCOReflectorCLI.sln 
+        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
+
+      - uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.x'
+          
+      - run: nuget pack src\JCOReflectorCLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -73,7 +73,7 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
+        run: dotnet build --no-incremental --configuration Release /p:Platform="Any CPU" src\JCOReflectorCLI.sln
 
       - uses: nuget/setup-nuget@v1
         with:
@@ -84,9 +84,9 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Copy configuration file
         run: |
-          Copy-Item .github\workflows\JCOReflectorCLI.runtimeconfig.json -Destination bin\netcoreapp3.1\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI.runtimeconfig.json -Destination bin\netcoreapp3.1\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
 
       - name: Remove Java files
         run: |
@@ -96,47 +96,47 @@ jobs:
           Remove-Item .\netreflected\src\net461 -Recurse -Force
 
       - name: Reflect .NET Core 3.1 Java files
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType Reflect -JobFile .github\workflows\reflect_netcoreapp3.1.job
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType Reflect -JobFile .github\workflows\reflect_netcoreapp3.1.job
 
       - name: Reflect .NET 5.0 Java files
-        run: .\bin\net5.0\JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net5.0.job
+        run: .\bin\net5.0\MASES.JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net5.0.job
         
       - name: Reflect .NET 6.0 Java files
-        run: .\bin\net6.0\JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net6.0.job
+        run: .\bin\net6.0\MASES.JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net6.0.job
           
       - name: Reflect .NET Framework Java files
-        run: .\bin\net461\JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net461.job
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net461.job
 
       - name: Build Java files .NET Core 3.1
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java files .NET Core 5.0
-        run: dotnet bin\net5.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java files .NET Core 6.0
-        run: dotnet bin\net6.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java files .NET Framework
-        run: .\bin\net461\JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Core 3.1
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Core 5.0
-        run: dotnet bin\net5.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Core 6.0
-        run: dotnet bin\net6.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Framework
-        run: .\bin\net461\JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java test source file .NET Core 3.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           nuget-version: '5.x'
           
-      - run: nuget pack src\JCOReflectorCLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
+      - run: nuget pack src\CLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,11 +31,13 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: |
-          dotnet build --no-incremental --framework netcoreapp3.1 --configuration Release src\JCOReflectorCLI.sln
-          dotnet build --no-incremental --framework net5.0 --configuration Release src\JCOReflectorCLI.sln  
-          dotnet build --no-incremental --framework net6.0 --configuration Release src\JCOReflectorCLI.sln 
-          dotnet build --no-incremental --framework net461 --configuration Release src\JCOReflectorCLI.sln  
+        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
+
+      - uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.x'
+          
+      - run: nuget pack src\JCOReflectorCLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file
@@ -195,11 +197,7 @@ jobs:
           asset_name: net461.docs.zip
           tag: ${{ github.ref }}
           overwrite: true
-          
-      - uses: nuget/setup-nuget@v1
-        with:
-          nuget-version: '5.x'
-          
+
       - name: Publish to NuGet
         run: |
           nuget push .\bin\*.nupkg -ApiKey ${{ secrets.MASES_NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json -SkipDuplicate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
+        run: dotnet build --no-incremental --configuration Release /p:Platform="Any CPU" src\JCOReflectorCLI.sln
 
       - uses: nuget/setup-nuget@v1
         with:
@@ -42,17 +42,17 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Copy configuration file
         run: |
-          Copy-Item .github\workflows\JCOReflectorCLI.runtimeconfig.json -Destination bin\netcoreapp3.1\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
 
       - name: Build net5.0 Maven POM files
-        run: dotnet bin\net5.0\JCOReflectorCLI.dll -JobType CreatePOM -POMStagingType Release -JobFile .github\workflows\createpom_win19.job
+        run: dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType CreatePOM -POMStagingType Release -JobFile .github\workflows\createpom_win19.job
 
       - name: Build net6.0 Maven POM files
-        run: dotnet bin\net6.0\JCOReflectorCLI.dll -JobType CreatePOM -POMStagingType Release -JobFile .github\workflows\createpom_win19.job
+        run: dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType CreatePOM -POMStagingType Release -JobFile .github\workflows\createpom_win19.job
           
       - name: Build net461 Maven POM files
-        run: .\bin\net461\JCOReflectorCLI -JobType CreatePOM -POMStagingType Release -JobFile .github\workflows\createpom_win19.job
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType CreatePOM -POMStagingType Release -JobFile .github\workflows\createpom_win19.job
 
       - name: Set up Apache Maven Central
         uses: actions/setup-java@v1
@@ -95,18 +95,18 @@ jobs:
       - name: Build Java files
       
         run: |
-          dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
-          dotnet bin\net5.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
-          dotnet bin\net6.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
-          .\bin\net461\JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          .\bin\net461\MASES.JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
           
       - name: Build JAR files
         run: |
-          dotnet .\bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job -JDKFolder %JAVA_HOME_11_X64%
-          dotnet .\bin\net5.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
-          dotnet .\bin\net6.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
-          .\bin\net461\JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet .\bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet .\bin\net5.0\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          dotnet .\bin\net6.0\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+          .\bin\net461\MASES.JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
 
       - name: Compress release files
@@ -122,9 +122,6 @@ jobs:
           Compress-Archive -Path .\netreflected\docs\net5.0\* -DestinationPath .\net5.0.docs.zip
           Compress-Archive -Path .\netreflected\docs\net6.0\* -DestinationPath .\net6.0.docs.zip
           Compress-Archive -Path .\netreflected\docs\net461\* -DestinationPath .\net461.docs.zip
-
-      - name: Build NuGet Packages
-        run: dotnet build --no-incremental --configuration Release /p:Platform="Any CPU" src\JCOReflectorCLI.sln
 
       - name: Upload netcoreapp3.1 binaries to release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/testbranch.yaml
+++ b/.github/workflows/testbranch.yaml
@@ -85,7 +85,7 @@ jobs:
         with:
           nuget-version: '5.x'
           
-      - run: nuget pack src\JCOReflectorCLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
+      - run: nuget pack src\CLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file

--- a/.github/workflows/testbranch.yaml
+++ b/.github/workflows/testbranch.yaml
@@ -79,11 +79,13 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: |
-          dotnet build --no-incremental --framework netcoreapp3.1 --configuration Release src\JCOReflectorCLI.sln
-          dotnet build --no-incremental --framework net5.0 --configuration Release src\JCOReflectorCLI.sln  
-          dotnet build --no-incremental --framework net6.0 --configuration Release src\JCOReflectorCLI.sln  
-          dotnet build --no-incremental --framework net461 --configuration Release src\JCOReflectorCLI.sln 
+        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
+
+      - uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.x'
+          
+      - run: nuget pack src\JCOReflectorCLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file

--- a/.github/workflows/testbranch.yaml
+++ b/.github/workflows/testbranch.yaml
@@ -79,7 +79,7 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
+        run: dotnet build --no-incremental --configuration Release /p:Platform="Any CPU" src\JCOReflectorCLI.sln
 
       - uses: nuget/setup-nuget@v1
         with:
@@ -90,9 +90,9 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Copy configuration file
         run: |
-          Copy-Item .github\workflows\JCOReflectorCLI.runtimeconfig.json -Destination bin\netcoreapp3.1\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI.runtimeconfig.json -Destination bin\netcoreapp3.1\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
       
       - name: Remove Java files
         run: |
@@ -102,47 +102,47 @@ jobs:
           Remove-Item .\netreflected\src\net461 -Recurse -Force
           
       - name: Reflect .NET Core 3.1 Java files
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType Reflect -JobFile .github\workflows\reflect_netcoreapp3.1.job
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType Reflect -JobFile .github\workflows\reflect_netcoreapp3.1.job
 
       - name: Reflect .NET 5.0 Java files
-        run: .\bin\net5.0\JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net5.0.job
+        run: .\bin\net5.0\MASES.JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net5.0.job
         
       - name: Reflect .NET 6.0 Java files
-        run: .\bin\net6.0\JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net6.0.job
+        run: .\bin\net6.0\MASES.JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net6.0.job
           
       - name: Reflect .NET Framework Java files
-        run: .\bin\net461\JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net461.job
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net461.job
 
       - name: Build Java files .NET Core 3.1
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java files .NET Core 5.0
-        run: dotnet bin\net5.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java files .NET Core 6.0
-        run: dotnet bin\net6.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java files .NET Framework
-        run: .\bin\net461\JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Core 3.1
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Core 5.0
-        run: dotnet bin\net5.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Core 6.0
-        run: dotnet bin\net6.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Framework
-        run: .\bin\net461\JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java test source file .NET Core 3.1
@@ -327,9 +327,6 @@ jobs:
       - run: cd ./netreflected-tests/scala && rmdir output /s /q
         shell: cmd  
 
-      - name: Build NuGet Packages
-        run: dotnet build --no-incremental --configuration Release /p:Platform="Any CPU" src\JCOReflectorCLI.sln
-       
       - name: Compress release files
         run: | 
           Compress-Archive -Path .\bin\netcoreapp3.1\* -DestinationPath .\bin\netcoreapp3.1.zip

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           nuget-version: '5.x'
           
-      - run: nuget pack src\JCOReflectorCLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
+      - run: nuget pack src\CLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -73,11 +73,13 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: |
-          dotnet build --no-incremental --framework netcoreapp3.1 --configuration Release src\JCOReflectorCLI.sln
-          dotnet build --no-incremental --framework net5.0 --configuration Release src\JCOReflectorCLI.sln  
-          dotnet build --no-incremental --framework net6.0 --configuration Release src\JCOReflectorCLI.sln  
-          dotnet build --no-incremental --framework net461 --configuration Release src\JCOReflectorCLI.sln  
+        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
+
+      - uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.x'
+          
+      - run: nuget pack src\JCOReflectorCLI\JCOReflectorCLI.nuspec -OutputDirectory .\bin
 
       # Runs a set of commands using the runners shell
       - name: Copy configuration file
@@ -325,9 +327,6 @@ jobs:
           Compress-Archive -Path .\bin\net5.0\* -DestinationPath .\bin\net5.0.zip
           Compress-Archive -Path .\bin\net6.0\* -DestinationPath .\bin\net6.0.zip
           Compress-Archive -Path .\bin\net461\* -DestinationPath .\bin\net461.zip
-
-      - name: Build NuGet Packages
-        run: dotnet build --no-incremental --configuration Release /p:Platform="Any CPU" src\JCOReflectorCLI.sln
 
       - name: Extract commit SHA
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -73,7 +73,7 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Build JCOReflectorCLI
-        run: dotnet build --no-incremental --configuration Release src\JCOReflectorCLI.sln
+        run: dotnet build --no-incremental --configuration Release /p:Platform="Any CPU" src\JCOReflectorCLI.sln
 
       - uses: nuget/setup-nuget@v1
         with:
@@ -84,9 +84,9 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Copy configuration file
         run: |
-          Copy-Item .github\workflows\JCOReflectorCLI.runtimeconfig.json -Destination bin\netcoreapp3.1\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\JCOReflectorCLI.runtimeconfig.json -Force
-          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI.runtimeconfig.json -Destination bin\netcoreapp3.1\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI5.0.runtimeconfig.json -Destination bin\net5.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
+          Copy-Item .github\workflows\JCOReflectorCLI6.0.runtimeconfig.json -Destination bin\net6.0\MASES.JCOReflectorCLI.runtimeconfig.json -Force
 
       - name: Remove Java files
         run: |
@@ -96,47 +96,47 @@ jobs:
           Remove-Item .\netreflected\src\net461 -Recurse -Force
 
       - name: Reflect .NET Core 3.1 Java files
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType Reflect -JobFile .github\workflows\reflect_netcoreapp3.1.job
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType Reflect -JobFile .github\workflows\reflect_netcoreapp3.1.job
 
       - name: Reflect .NET 5.0 Java files
-        run: .\bin\net5.0\JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net5.0.job
+        run: .\bin\net5.0\MASES.JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net5.0.job
         
       - name: Reflect .NET 6.0 Java files
-        run: .\bin\net6.0\JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net6.0.job
+        run: .\bin\net6.0\MASES.JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net6.0.job
           
       - name: Reflect .NET Framework Java files
-        run: .\bin\net461\JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net461.job
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType Reflect -JobFile .github\workflows\reflect_net461.job
 
       - name: Build Java files .NET Core 3.1
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java files .NET Core 5.0
-        run: dotnet bin\net5.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java files .NET Core 6.0
-        run: dotnet bin\net6.0\JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java files .NET Framework
-        run: .\bin\net461\JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType Build -JobFile .github\workflows\build_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Core 3.1
-        run: dotnet bin\netcoreapp3.1\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\netcoreapp3.1\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core3.1_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Core 5.0
-        run: dotnet bin\net5.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net5.0\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core5.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Core 6.0
-        run: dotnet bin\net6.0\JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: dotnet bin\net6.0\MASES.JCOReflectorCLI.dll -JobType CreateJars -JobFile .github\workflows\createjars_core6.0_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build JAR files .NET Framework
-        run: .\bin\net461\JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job -JDKFolder %JAVA_HOME_11_X64%
+        run: .\bin\net461\MASES.JCOReflectorCLI -JobType CreateJars -JobFile .github\workflows\createjars_framework_win19.job -JDKFolder %JAVA_HOME_11_X64%
         shell: cmd
         
       - name: Build Java test source file .NET Core 3.1

--- a/src/CLI/DotnetToolSettings.xml
+++ b/src/CLI/DotnetToolSettings.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DotNetCliTool Version="1">
+	<Commands>
+		<Command Name="JCOReflectorCLI" EntryPoint="MASES.JCOReflectorCLI.dll" Runner="dotnet" />
+	</Commands>
+</DotNetCliTool>

--- a/src/CLI/JCOReflectorCLI.csproj
+++ b/src/CLI/JCOReflectorCLI.csproj
@@ -12,7 +12,7 @@
     <Version>1.8.5.0</Version>
     <Product>MASES.JCOReflectorCLI</Product>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin\</OutputPath>
     <!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/CLI/JCOReflectorCLI.csproj
+++ b/src/CLI/JCOReflectorCLI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<PackageType>DotnetTool</PackageType>
+    <PackageType>DotnetTool</PackageType>
     <OutputType>Exe</OutputType>
     <AssemblyName>MASES.JCOReflectorCLI</AssemblyName>
     <RootNamespace>MASES.JCOReflectorCLI</RootNamespace>
@@ -28,7 +28,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Common\JCOReflector.snk</AssemblyOriginatorKeyFile>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <!-- Fix start https://github.com/dotnet/sourcelink/issues/572 -->
   <PropertyGroup>
@@ -45,13 +45,13 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
     <None Include="..\Common\JCOB128x128.png" Pack="true" PackagePath="" />
     <None Include="..\Common\JCOReflector.snk" Link="JCOReflector.snk" />
-	<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
-	<ProjectReference Include="..\engine\JCOReflectorEngine.csproj">
-      <IncludeAssets>All</IncludeAssets>
-      <PrivateAssets>None</PrivateAssets>
-	</ProjectReference>
+  <ProjectReference Include="..\engine\JCOReflectorEngine.csproj">
+    <IncludeAssets>All</IncludeAssets>
+    <PrivateAssets>None</PrivateAssets>
+  </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/CLI/JCOReflectorCLI.csproj
+++ b/src/CLI/JCOReflectorCLI.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+	<PackageType>DotnetTool</PackageType>
     <OutputType>Exe</OutputType>
-    <AssemblyName>JCOReflectorCLI</AssemblyName>
+    <AssemblyName>MASES.JCOReflectorCLI</AssemblyName>
     <RootNamespace>MASES.JCOReflectorCLI</RootNamespace>
     <Title>JCOReflector CLI - CLI interface for JCOReflector Engine</Title>
     <Description>JCOReflector CLI - CLI interface for JCOReflector Engine</Description>
@@ -11,22 +12,23 @@
     <Version>1.8.5.0</Version>
     <Product>MASES.JCOReflectorCLI</Product>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin\</OutputPath>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/masesgroup/JCOReflector/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/masesgroup/JCOReflector</RepositoryUrl>
     <PackageReleaseNotes>https://github.com/masesgroup/JCOReflector/releases</PackageReleaseNotes>
     <PackageLicense>LICENSE</PackageLicense>
     <PackageIcon>JCOB128x128.png</PackageIcon>
-    <PackageTags>jvm-enabled-language kotlin java scala reflection dotnet clr netcore bridge jcobridge class framework csharp</PackageTags>
+    <PackageTags>jcoreflector cli jvm-enabled-language kotlin java scala reflection dotnet clr netcore bridge jcobridge class framework csharp</PackageTags>
     <PackageId>MASES.JCOReflectorCLI</PackageId>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Common\JCOReflector.snk</AssemblyOriginatorKeyFile>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <!-- Fix start https://github.com/dotnet/sourcelink/issues/572 -->
   <PropertyGroup>
@@ -43,11 +45,20 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
     <None Include="..\Common\JCOB128x128.png" Pack="true" PackagePath="" />
     <None Include="..\Common\JCOReflector.snk" Link="JCOReflector.snk" />
+	<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\engine\JCOReflectorEngine.csproj" />
+	<ProjectReference Include="..\engine\JCOReflectorEngine.csproj">
+      <IncludeAssets>All</IncludeAssets>
+      <PrivateAssets>None</PrivateAssets>
+	</ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="DotnetToolSettings.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/CLI/JCOReflectorCLI.csproj
+++ b/src/CLI/JCOReflectorCLI.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright ©  MASES s.r.l. 2022</Copyright>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>1.8.4.0</Version>
+    <Version>1.8.5.0</Version>
     <Product>MASES.JCOReflectorCLI</Product>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>

--- a/src/CLI/JCOReflectorCLI.nuspec
+++ b/src/CLI/JCOReflectorCLI.nuspec
@@ -5,10 +5,10 @@
     <version>1.8.5</version>
     <title>JCOReflector CLI - CLI interface for JCOReflector Engine</title>
     <authors>MASES s.r.l.</authors>
-	<owners>MASES s.r.l.</owners>
+    <owners>MASES s.r.l.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectUrl>https://github.com/masesgroup/JCOReflector/</projectUrl>
-	<repository type="git" url="https://github.com/masesgroup/JCOReflector/" />
+    <repository type="git" url="https://github.com/masesgroup/JCOReflector/" />
     <description>JCOReflector CLI - CLI interface for JCOReflector Engine</description>
     <releaseNotes>https://github.com/masesgroup/JCOReflector/releases</releaseNotes>
     <copyright>Copyright ©  MASES s.r.l. 2022</copyright>
@@ -18,14 +18,14 @@
     <packageTypes>
       <packageType name="DotnetTool" />
     </packageTypes>
-	<readme>README.md</readme>
+    <readme>README.md</readme>
   </metadata>
-	<files>
-		<file src="..\..\LICENSE" target="LICENSE" />
-		<file src="..\Common\JCOB128x128.png" target="" />
-		<file src="..\..\README.md" target="" />
-		<file src="..\..\bin\netcoreapp3.1\" target="tools\netcoreapp3.1\any" />
-		<file src="..\..\bin\net5.0\" target="tools\net5.0\any" />
-		<file src="..\..\bin\net6.0\" target="tools\net6.0\any" />
-	</files>
+    <files>
+        <file src="..\..\LICENSE" target="LICENSE" />
+        <file src="..\Common\JCOB128x128.png" target="" />
+        <file src="..\..\README.md" target="" />
+        <file src="..\..\bin\netcoreapp3.1\" target="tools\netcoreapp3.1\any" />
+        <file src="..\..\bin\net5.0\" target="tools\net5.0\any" />
+        <file src="..\..\bin\net6.0\" target="tools\net6.0\any" />
+    </files>
 </package>

--- a/src/CLI/JCOReflectorCLI.nuspec
+++ b/src/CLI/JCOReflectorCLI.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>MASES.JCOReflectorCLI</id>
+    <version>1.8.5</version>
+    <title>JCOReflector CLI - CLI interface for JCOReflector Engine</title>
+    <authors>MASES s.r.l.</authors>
+	<owners>MASES s.r.l.</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectUrl>https://github.com/masesgroup/JCOReflector/</projectUrl>
+	<repository type="git" url="https://github.com/masesgroup/JCOReflector/" />
+    <description>JCOReflector CLI - CLI interface for JCOReflector Engine</description>
+    <releaseNotes>https://github.com/masesgroup/JCOReflector/releases</releaseNotes>
+    <copyright>Copyright ©  MASES s.r.l. 2022</copyright>
+    <license type="file">LICENSE</license>
+    <icon>JCOB128x128.png</icon>
+    <tags>jcoreflector cli jvm-enabled-language kotlin java scala reflection dotnet clr netcore bridge jcobridge class framework csharp</tags>
+    <packageTypes>
+      <packageType name="DotnetTool" />
+    </packageTypes>
+	<readme>README.md</readme>
+  </metadata>
+	<files>
+		<file src="..\..\LICENSE" target="LICENSE" />
+		<file src="..\Common\JCOB128x128.png" target="" />
+		<file src="..\..\README.md" target="" />
+		<file src="..\..\bin\netcoreapp3.1\" target="tools\netcoreapp3.1\any" />
+		<file src="..\..\bin\net5.0\" target="tools\net5.0\any" />
+		<file src="..\..\bin\net6.0\" target="tools\net6.0\any" />
+	</files>
+</package>

--- a/src/GUI/JCOReflectorGUI.csproj
+++ b/src/GUI/JCOReflectorGUI.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright ©  MASES s.r.l. 2022</Copyright>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>1.8.4.0</Version>
+    <Version>1.8.5.0</Version>
     <Product>JCOReflectorGUI</Product>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <TargetFrameworks>net461;netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>

--- a/src/engine/Const.cs
+++ b/src/engine/Const.cs
@@ -55,7 +55,8 @@ namespace MASES.JCOReflectorEngine
             "continue",
             "Class",
             "classType",
-            "classInstance"
+            "classInstance",
+            "native"
         };
 
         public class SpecialNames

--- a/src/engine/JCOReflectorEngine.csproj
+++ b/src/engine/JCOReflectorEngine.csproj
@@ -26,7 +26,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Common\JCOReflector.snk</AssemblyOriginatorKeyFile>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <!-- Fix start https://github.com/dotnet/sourcelink/issues/572 -->
   <PropertyGroup>
@@ -105,13 +105,13 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
     <None Include="..\Common\JCOB128x128.png" Pack="true" PackagePath="" />
     <None Include="..\Common\JCOReflector.snk" Link="JCOReflector.snk" />
-	<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MASES.CLIParser" Version="2.2.1" />
     <PackageReference Include="MASES.JCOBridge" Version="2.4.6">
-        <IncludeAssets>All</IncludeAssets>
-        <PrivateAssets>None</PrivateAssets>
+      <IncludeAssets>All</IncludeAssets>
+      <PrivateAssets>None</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/engine/JCOReflectorEngine.csproj
+++ b/src/engine/JCOReflectorEngine.csproj
@@ -10,7 +10,7 @@
     <Version>1.8.5.0</Version>
     <Product>MASES.JCOReflectorEngine</Product>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <TargetFrameworks>net461;netcoreapp3.1;net5.0;net5.0-windows;net6.0;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin\</OutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -19,13 +19,14 @@
     <PackageReleaseNotes>https://github.com/masesgroup/JCOReflector/releases</PackageReleaseNotes>
     <PackageLicense>LICENSE</PackageLicense>
     <PackageIcon>JCOB128x128.png</PackageIcon>
-    <PackageTags>jvm-enabled-language kotlin java scala reflection dotnet clr netcore bridge jcobridge class framework csharp</PackageTags>
+    <PackageTags>jcoreflector jvm-enabled-language kotlin java scala reflection dotnet clr netcore bridge jcobridge class framework csharp</PackageTags>
     <PackageId>MASES.JCOReflectorEngine</PackageId>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Common\JCOReflector.snk</AssemblyOriginatorKeyFile>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <!-- Fix start https://github.com/dotnet/sourcelink/issues/572 -->
   <PropertyGroup>
@@ -104,6 +105,7 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
     <None Include="..\Common\JCOB128x128.png" Pack="true" PackagePath="" />
     <None Include="..\Common\JCOReflector.snk" Link="JCOReflector.snk" />
+	<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MASES.CLIParser" Version="2.2.1" />

--- a/src/engine/JCOReflectorEngine.csproj
+++ b/src/engine/JCOReflectorEngine.csproj
@@ -7,7 +7,7 @@
     <Copyright>Copyright ©  MASES s.r.l. 2022</Copyright>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>1.8.4.0</Version>
+    <Version>1.8.5.0</Version>
     <Product>MASES.JCOReflectorEngine</Product>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <TargetFrameworks>net461;netcoreapp3.1;net5.0;net5.0-windows;net6.0;net6.0-windows</TargetFrameworks>


### PR DESCRIPTION
## Description
JCOReflectorCLI will appear in nuget.org as a dotnet tool, meanwhile was corrected the package name generation.

## Related Issue
Closed #77 
Closed #78 

## Motivation and Context
Changes requested from open issues.

## How Has This Been Tested?
Locally tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
